### PR TITLE
Adds support for custom message templates using ERB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+ - Support for custom message templates
 
 ## 0.2.0 - 2016-03-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ This gem also expects a JSON configuration file with the following contents:
   message to Telegram (ie. connectivity issues), the exception mesage will
   be written to a file in this location. You can then monitor this
   location to detect any errors with the Telegram handler.
+- `message_template` (optional): An ERB template to use to format messages
+  instead of the default. Supports the following variables:
+  - `action_name`
+  - `action_icon`
+  - `client_name`
+  - `check_name`
+  - `status`
+  - `status_icon`
+  - `output`
+- `message_template_file` (optional): A file to read an ERB template from to
+  format messages. Supports the same variables as `message_template`.
+
 
 ### Advanced configuration
 

--- a/bin/handler-telegram.rb
+++ b/bin/handler-telegram.rb
@@ -127,7 +127,7 @@ class TelegramHandler < Sensu::Handler
   def default_message
     [
       '<b>Alert <%= action_name %></b> <%= action_icon %>',
-      '<b>Hostess:</b> <%= client_name %>',
+      '<b>Host:</b> <%= client_name %>',
       '<b>Check:</b> <%= check_name %>',
       '<b>Status:</b> <%= status %> <%= status_icon %>',
       '<b>Output:</b> <code><%= output %></code>'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No!

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

I wanted to be able to specify a custom message format to send to telegram, as I prefer something different from the default. This patch allows users to specify that format as an ERB template using either an inline string in the configuration or loaded from a file. Have tested it pretty thoroughly in my own setup, but I'm a novice at Ruby, so code review is much appreciated.