### PR TITLE
Release 3.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following [this format](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 ---
+AllCops:
+  TargetRubyVersion: 2.3
 
 MethodLength:
   Max: 200

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.1
-- 2.2
 - 2.3.0
 - 2.4.1
+- 2.5.3
 notifications:
   email:
     recipients:
@@ -26,8 +25,7 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.1
-    rvm: 2.2
     rvm: 2.3.0
     rvm: 2.4.1
+    rvm: 2.5.3
     repo: sensu-plugins/sensu-plugins-telegram

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Breaking Changes
 - Remove support for Ruby < 2.3 per the Sensu Plugins [policy](https://github.com/sensu/sensu-docs/blob/master/content/plugins/1.0/faq.md#what-is-the-policy-on-supporting-end-of-lifeeol-ruby-versions).
 
-## [1.0.1] - 2017-07-29
+## [2.0.1] - 2017-07-29
 ### Fixed
 - use rest-client 2 to fix issue with OpenSSL 1.1.0 (@ushis)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows [this format](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+
+## [3.0.0] - 2018-11-24
 ### Breaking Changes
 - Remove support for Ruby < 2.3 per the Sensu Plugins [policy](https://github.com/sensu/sensu-docs/blob/master/content/plugins/1.0/faq.md#what-is-the-policy-on-supporting-end-of-lifeeol-ruby-versions).
+- Update sensu-plugins to `~> 2.7`. Many breaking changes, see:
+  - [1.4.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v140---2016-07-20)
+  - [2.0.0](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v200---2017-03-29)
 
 ### Security
 - Updated Rubocop to `~> 0.60.0`, which fixes [CVE-2017-8418](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Breaking Changes
 - Remove support for Ruby < 2.3 per the Sensu Plugins [policy](https://github.com/sensu/sensu-docs/blob/master/content/plugins/1.0/faq.md#what-is-the-policy-on-supporting-end-of-lifeeol-ruby-versions).
 
+### Changed
+- Relaxed the rest-client version, since it doesn't need to be so specific, and `gem build` was showing a warning.
+
 ## [2.0.1] - 2017-07-29
 ### Fixed
 - use rest-client 2 to fix issue with OpenSSL 1.1.0 (@ushis)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows [this format](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Breaking Changes
 - Remove support for Ruby < 2.3 per the Sensu Plugins [policy](https://github.com/sensu/sensu-docs/blob/master/content/plugins/1.0/faq.md#what-is-the-policy-on-supporting-end-of-lifeeol-ruby-versions).
 
+### Security
+- Updated Rubocop to `~> 0.60.0`, which fixes [CVE-2017-8418](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418).
+- Updated Yard to `~> 0.9.11`, which fixes [CVE-2017-17042](https://nvd.nist.gov/vuln/detail/CVE-2017-17042).
+
 ### Changed
 - Relaxed the rest-client version, since it doesn't need to be so specific, and `gem build` was showing a warning.
+- Fixed cop violations
 
 ## [2.0.1] - 2017-07-29
 ### Fixed
@@ -33,9 +38,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [0.2.0] - 2016-03-23
 ### Added
  - Emojis!
- - The json_config command line option, which lets you specify custom configs
+ - The `json_config` command line option, which lets you specify custom configs
    for different handlers.
- - the bot_token and error_file_location settings can also be specified
+ - the `bot_token` and `error_file_location` settings can also be specified
    directly in the event data.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- Remove support for Ruby < 2.3 per the Sensu Plugins [policy](https://github.com/sensu/sensu-docs/blob/master/content/plugins/1.0/faq.md#what-is-the-policy-on-supporting-end-of-lifeeol-ruby-versions).
 
 ## [1.0.1] - 2017-07-29
 ### Fixed
 - use rest-client 2 to fix issue with OpenSSL 1.1.0 (@ushis)
 
 ## [2.0.0] - 2017-05-30
-### Breaking Change
+### Breaking Changes
 - removed ruby 1.9x support
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in sensu-plugins-telegram.gemspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-telegram.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-telegram)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-telegram.svg)](http://badge.fury.io/rb/sensu-plugins-telegram)
-[![Dependency Status](https://gemnasium.com/sensu-plugins/sensu-plugins-telegram.svg)](https://gemnasium.com/sensu-plugins/sensu-plugins-telegram)
 
 ## Functionality
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ After installation, you have to set up a `pipe` type handler, like so:
   "handlers": {
     "telegram": {
       "type": "pipe",
-      "command": "handler-telegram.rb"
+      "command": "handler-telegram.rb",
+      "filter": "occurrences"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ This gem also expects a JSON configuration file with the following contents:
    [@BotFather](https://telegram.me/botfather).
 - `chat_id`: the chat to which the error message is to be sent.
   The bot must be a member of this channel or group.
-  You can get this chat_id by adding the bot to the corresponding group
-  and then accessing `https://api.telegram.org/bot<TOKEN>/getUpdates`.
+  You can get the `chat_id` by adding the bot to the corresponding group,
+  sending a message like `/fakecmd @your-bot-username`, and then accessing
+  `https://api.telegram.org/bot<TOKEN>/getUpdates`.
 - `error_file_location` (optional): in case there is a failure sending the
   message to Telegram (ie. connectivity issues), the exception mesage will
   be written to a file in this location. You can then monitor this

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'github/markup'
 require 'redcarpet'
@@ -7,9 +9,9 @@ require 'yard'
 require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +37,4 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+task default: %i[spec make_bin_executable yard rubocop check_binstubs]

--- a/bin/handler-telegram.rb
+++ b/bin/handler-telegram.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 #
 #   handler-telegram
 #
@@ -143,11 +145,13 @@ class TelegramHandler < Sensu::Handler
   end
 
   def handle_error(exception)
-    open(error_file, 'w') do |f|
+    return unless error_file
+
+    File.open(error_file, 'w') do |f|
       f.puts 'URL: ' + telegram_url
       f.puts 'Params: ' + params.inspect
       f.puts 'Exception: ' + exception.inspect
-    end if error_file
+    end
   end
 
   def clear_error

--- a/bin/handler-telegram.rb
+++ b/bin/handler-telegram.rb
@@ -35,7 +35,6 @@
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 require 'restclient'
 require 'cgi'

--- a/lib/sensu-plugins-telegram.rb
+++ b/lib/sensu-plugins-telegram.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require 'sensu-plugins-telegram/version'

--- a/lib/sensu-plugins-telegram/version.rb
+++ b/lib/sensu-plugins-telegram/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SensuPluginsTelegram
   module Version
     MAJOR = 2

--- a/lib/sensu-plugins-telegram/version.rb
+++ b/lib/sensu-plugins-telegram/version.rb
@@ -2,9 +2,9 @@
 
 module SensuPluginsTelegram
   module Version
-    MAJOR = 2
+    MAJOR = 3
     MINOR = 0
-    PATCH = 1
+    PATCH = 0
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-telegram.gemspec
+++ b/sensu-plugins-telegram.gemspec
@@ -37,8 +37,8 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsTelegram::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.1'
   s.add_runtime_dependency 'rest-client',  '~> 2.0'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-telegram.gemspec
+++ b/sensu-plugins-telegram.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.3.0'
   s.summary                = 'Sensu plugins for interfacing with Telegram messenger'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsTelegram::Version::VER_STRING

--- a/sensu-plugins-telegram.gemspec
+++ b/sensu-plugins-telegram.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsTelegram::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.1'
-  s.add_runtime_dependency 'rest-client',  '~> 2.0.2'
+  s.add_runtime_dependency 'rest-client',  '~> 2.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'

--- a/sensu-plugins-telegram.gemspec
+++ b/sensu-plugins-telegram.gemspec
@@ -1,30 +1,32 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
 
 require_relative 'lib/sensu-plugins-telegram'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors = [
     'Hernan Schmidt',
     'Sensu-Plugins and contributors'
   ]
 
   s.date                   = Date.today.to_s
-  s.description            = 'Sensu plugins for interfacing with Telegram messenger'
+  s.description            = 'Sensu plugin for interfacing with Telegram messenger'
   s.email                  = [
     'hschmidt@suse.de',
     'sensu-users@googlegroups.com'
   ]
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-telegram'
   s.license                = 'MIT'
-  s.metadata               = { 'maintainer'         => 'sensu-plugin',
+  s.metadata               = { 'maintainer' => 'sensu-plugin',
                                'development_status' => 'active',
-                               'production_status'  => 'unstable - testing recommended',
-                               'release_draft'      => 'false',
+                               'production_status' => 'unstable - testing recommended',
+                               'release_draft' => 'false',
                                'release_prerelease' => 'false' }
   s.name                   = 'sensu-plugins-telegram'
   s.platform               = Gem::Platform::RUBY
@@ -44,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
+  s.add_development_dependency 'yard',                      '~> 0.9.11'
 end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start


### PR DESCRIPTION
## Pull Request Checklist
#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

- Cut a new version of the gem.
- Does not change, add or remove any functionality from the previous version.
- Updated instructions to get chat_id
- Update link to Changelog guidelines
- Update sensu-plugins to `~> 2.7`, which includes breaking changes
- Update Rubocop to latest, and fix violations
- Fix strictness of rest-client gem dependency
- Remove obsolete Gemnasium badge
- Fix typo in 2.0.1 changelog header
- Remove support for Ruby < 2.3 per the Sensu Plugins policy
